### PR TITLE
Add vscode task for run dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ Dockerfile
 .gitignore
 .pre-commit-config.yaml
 biome.json
+node_modules

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run dev",
+            "command": "bun --bun --watch dev",
+            "type": "shell",
+            "args": [],
+            "problemMatcher": [
+                "$tsc"
+            ],
+            "presentation": {
+                "reveal": "always"
+            },
+            "group": "build"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request adds a new vscode task for running the development server. The task is configured to run the command "bun --bun --watch dev" and is included in the "build" task group. This will make it easier for developers to start the development server directly from within vscode.